### PR TITLE
Make transform method protected. 

### DIFF
--- a/src/router/Transformer.ts
+++ b/src/router/Transformer.ts
@@ -25,5 +25,5 @@ export abstract class Transformer <T, S> {
     return entities.map(entity => this.transform(entity))
   }
 
-  abstract transform (_entity: T): S
+  protected abstract transform (_entity: T): S
 }


### PR DESCRIPTION
Make transform method protected. Transformer users only need to know the item and array operations.